### PR TITLE
Add URI link type and tests

### DIFF
--- a/src/pubget/_links.py
+++ b/src/pubget/_links.py
@@ -78,6 +78,7 @@ def neurovault_id_extractors() -> Tuple[Extractor, Extractor]:
         LinkContentExtractor(
             r"""(?x)
             .*(?:neurovault.org/collections/
+            |neurovault.org/api/collections/
             |identifiers.org/neurovault.collection:)
             (?P<collection_id>\w+)
             """,
@@ -86,6 +87,7 @@ def neurovault_id_extractors() -> Tuple[Extractor, Extractor]:
         LinkContentExtractor(
             r"""(?x)
             .*(?:neurovault.org/images/
+            |neurovault.org/api/images/
             |identifiers.org/neurovault.image:)
             (?P<image_id>\d+)
             """,

--- a/src/pubget/_links.py
+++ b/src/pubget/_links.py
@@ -30,7 +30,7 @@ class LinkExtractor(Extractor):
         pmcid = _utils.get_pmcid(article)
         all_links = []
         xlink = "http://www.w3.org/1999/xlink"
-        for tag in ['uri', 'ext-link']:
+        for tag in ["uri", "ext-link"]:
             for link in article.iterfind(f"//{tag}[@{{{xlink}}}href]"):
                 href = link.get(f"{{{xlink}}}href")
                 link_type = link.get("ext-link-type") or tag

--- a/src/pubget/_links.py
+++ b/src/pubget/_links.py
@@ -30,12 +30,13 @@ class LinkExtractor(Extractor):
         pmcid = _utils.get_pmcid(article)
         all_links = []
         xlink = "http://www.w3.org/1999/xlink"
-        for link in article.iterfind(f"//ext-link[@{{{xlink}}}href]"):
-            href = link.get(f"{{{xlink}}}href")
-            link_type = link.get("ext-link-type")
-            all_links.append(
-                {"pmcid": pmcid, "ext-link-type": link_type, "href": href}
-            )
+        for tag in ['uri', 'ext-link']:
+            for link in article.iterfind(f"//{tag}[@{{{xlink}}}href]"):
+                href = link.get(f"{{{xlink}}}href")
+                link_type = link.get("ext-link-type")
+                all_links.append(
+                    {"pmcid": pmcid, "ext-link-type": link_type, "href": href}
+                )
         return pd.DataFrame(all_links, columns=self.fields).drop_duplicates()
 
 

--- a/src/pubget/_links.py
+++ b/src/pubget/_links.py
@@ -33,7 +33,7 @@ class LinkExtractor(Extractor):
         for tag in ['uri', 'ext-link']:
             for link in article.iterfind(f"//{tag}[@{{{xlink}}}href]"):
                 href = link.get(f"{{{xlink}}}href")
-                link_type = link.get("ext-link-type")
+                link_type = link.get("ext-link-type") or tag
                 all_links.append(
                     {"pmcid": pmcid, "ext-link-type": link_type, "href": href}
                 )

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -22,17 +22,19 @@ def test_link_extractor(n_links):
     </body>
 </article>
     """
-    one_link = (
+    two_links = (
         b'link <ext-link xlink:href="http:example.com/%d">'
-        b"http:example.com</ext-link>"
+        b'http:example.com</ext-link>'
+        b'link <uri xlink:href="http:example.com/%d">'
+        b"http:example.com</uri>"
     )
-    links_text = b"\n".join([one_link % i for i in range(n_links)])
+    links_text = b"\n".join([two_links % (i, i+10) for i in range(n_links)])
     xml = xml_template % links_text
     document = etree.ElementTree(etree.XML(xml))
     extracted = _links.LinkExtractor().extract(
         document, pathlib.Path("pmc_9057060"), {}
     )
-    assert extracted.shape == (n_links, 3)
+    assert extracted.shape == (n_links * 2, 3)
 
 
 def test_link_content_extractor():

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -42,10 +42,12 @@ def test_link_content_extractor():
         {
             "href": [
                 "https://neurovault.org/collections/12/",
+                "https://neurovault.org/api/collections/16/",
                 "identifiers.org/neurovault.collection:a13",
                 "neurovault.org/collections/14a",
                 "https://neurovault.org/images/3",
                 "identifiers.org/neurovault.image:2",
+                "https://neurovault.org/api/images/22/"
             ],
             "pmcid": 7,
         }
@@ -57,7 +59,7 @@ def test_link_content_extractor():
         (
             col
             == pd.DataFrame(
-                {"pmcid": 7, "collection_id": ["12", "a13", "14a"]}
+                {"pmcid": 7, "collection_id": ["12", "16", "a13", "14a"]}
             )
         )
         .all()
@@ -65,7 +67,7 @@ def test_link_content_extractor():
     )
     img = img_extract.extract(None, None, data)
     assert (
-        (img == pd.DataFrame({"pmcid": 7, "image_id": ["3", "2"]})).all().all()
+        (img == pd.DataFrame({"pmcid": 7, "image_id": ["3", "2", "22"]})).all().all()
     )
     col = col_extract.extract(None, None, pd.DataFrame())
     assert col.shape == (0, 2)

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -24,11 +24,11 @@ def test_link_extractor(n_links):
     """
     two_links = (
         b'link <ext-link xlink:href="http:example.com/%d">'
-        b'http:example.com</ext-link>'
+        b"http:example.com</ext-link>"
         b'link <uri xlink:href="http:example.com/%d">'
         b"http:example.com</uri>"
     )
-    links_text = b"\n".join([two_links % (i, i+10) for i in range(n_links)])
+    links_text = b"\n".join([two_links % (i, i + 10) for i in range(n_links)])
     xml = xml_template % links_text
     document = etree.ElementTree(etree.XML(xml))
     extracted = _links.LinkExtractor().extract(
@@ -47,7 +47,7 @@ def test_link_content_extractor():
                 "neurovault.org/collections/14a",
                 "https://neurovault.org/images/3",
                 "identifiers.org/neurovault.image:2",
-                "https://neurovault.org/api/images/22/"
+                "https://neurovault.org/api/images/22/",
             ],
             "pmcid": 7,
         }
@@ -67,7 +67,9 @@ def test_link_content_extractor():
     )
     img = img_extract.extract(None, None, data)
     assert (
-        (img == pd.DataFrame({"pmcid": 7, "image_id": ["3", "2", "22"]})).all().all()
+        (img == pd.DataFrame({"pmcid": 7, "image_id": ["3", "2", "22"]}))
+        .all()
+        .all()
     )
     col = col_extract.extract(None, None, pd.DataFrame())
     assert col.shape == (0, 2)


### PR DESCRIPTION
Fixes #33 

- Adds "URI" as a type of tag that can be used to extract links
- Sets links_type to tag type (i.e. `uri`) if this no type found (which happens with the uri tag)
- Modifies test to include example and double number of links expected
- Adds the following (rare but possible) pattern: api preceding image or collection id