### PR TITLE
Preserve Links and Text related to Public Dataset

### DIFF
--- a/src/pubget/_data/stylesheets/text_extraction.xsl
+++ b/src/pubget/_data/stylesheets/text_extraction.xsl
@@ -164,7 +164,6 @@
   <xsl:template match="equation-count" />
   <xsl:template match="era" />
   <xsl:template match="etal" />
-  <!-- <xsl:template match="ext-link" /> -->
   <xsl:template match="fax" />
   <xsl:template match="fig-count" />
   <xsl:template match="fn" />

--- a/src/pubget/_data/stylesheets/text_extraction.xsl
+++ b/src/pubget/_data/stylesheets/text_extraction.xsl
@@ -217,7 +217,7 @@
   <xsl:template match="named-content" />
   <xsl:template match="nlm-citation" />
   <xsl:template match="note" />
-  <!-- <xsl:template match="notes" /> -->
+  <xsl:template match="notes" />
   <xsl:template match="oasis:table" />
   <xsl:template match="object-id" />
   <xsl:template match="on-behalf-of" />

--- a/src/pubget/_data/stylesheets/text_extraction.xsl
+++ b/src/pubget/_data/stylesheets/text_extraction.xsl
@@ -25,7 +25,17 @@
       <body>
         <xsl:apply-templates select="/article/body" />
       </body>
+      <datasets>
+      <xsl:apply-templates select="/article/back//notes[@notes-type='data-availability']" />
+      </datasets>
     </extracted-text>
+  </xsl:template>
+
+ <xsl:template match="/article/back//notes[@notes-type='data-availability']">
+    <xsl:for-each select=".//p | .//ext-link[@ext-link-type='uri']">
+      <xsl:value-of select="normalize-space(.)" />
+      <xsl:text> </xsl:text>
+    </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="*" >
@@ -151,7 +161,7 @@
   <xsl:template match="equation-count" />
   <xsl:template match="era" />
   <xsl:template match="etal" />
-  <xsl:template match="ext-link" />
+  <!-- <xsl:template match="ext-link" /> -->
   <xsl:template match="fax" />
   <xsl:template match="fig-count" />
   <xsl:template match="fn" />
@@ -204,7 +214,7 @@
   <xsl:template match="named-content" />
   <xsl:template match="nlm-citation" />
   <xsl:template match="note" />
-  <xsl:template match="notes" />
+  <!-- <xsl:template match="notes" /> -->
   <xsl:template match="oasis:table" />
   <xsl:template match="object-id" />
   <xsl:template match="on-behalf-of" />

--- a/src/pubget/_data/stylesheets/text_extraction.xsl
+++ b/src/pubget/_data/stylesheets/text_extraction.xsl
@@ -32,7 +32,7 @@
   <xsl:template match="/article/back//*[self::notes or self::sec][(self::notes and @notes-type='data-availability') or (self::sec and @sec-type='data-availability')]">
     <xsl:variable name="title" select=".//title"/>
     <xsl:if test="$title">
-      <xsl:value-of select="concat('#', normalize-space($title))"/>
+      <xsl:value-of select="concat('## ', normalize-space($title))"/>
       <xsl:text>&#10;</xsl:text>
     </xsl:if>
     <xsl:for-each select=".//p | .//ext-link[@ext-link-type='uri']">

--- a/src/pubget/_data/stylesheets/text_extraction.xsl
+++ b/src/pubget/_data/stylesheets/text_extraction.xsl
@@ -24,16 +24,19 @@
       </abstract>
       <body>
         <xsl:apply-templates select="/article/body" />
+       <xsl:apply-templates select="/article/back//*[self::notes[@notes-type='data-availability'] or self::sec[@sec-type='data-availability']]"/>
       </body>
-      <datasets>
-      <xsl:apply-templates select="/article/back//notes[@notes-type='data-availability']" />
-      </datasets>
     </extracted-text>
   </xsl:template>
 
- <xsl:template match="/article/back//notes[@notes-type='data-availability']">
+  <xsl:template match="/article/back//*[self::notes or self::sec][(self::notes and @notes-type='data-availability') or (self::sec and @sec-type='data-availability')]">
+    <xsl:variable name="title" select=".//title"/>
+    <xsl:if test="$title">
+      <xsl:value-of select="concat('#', normalize-space($title))"/>
+      <xsl:text>&#10;</xsl:text>
+    </xsl:if>
     <xsl:for-each select=".//p | .//ext-link[@ext-link-type='uri']">
-      <xsl:value-of select="normalize-space(.)" />
+      <xsl:value-of select="normalize-space(.)"/>
       <xsl:text> </xsl:text>
     </xsl:for-each>
   </xsl:template>

--- a/src/pubget/_data/stylesheets/text_extraction.xsl
+++ b/src/pubget/_data/stylesheets/text_extraction.xsl
@@ -33,7 +33,7 @@
     <xsl:variable name="title" select=".//title"/>
     <xsl:if test="$title">
       <xsl:value-of select="concat('## ', normalize-space($title))"/>
-      <xsl:text>&#10;</xsl:text>
+      <xsl:text>&#10;&#10;</xsl:text>
     </xsl:if>
     <xsl:for-each select=".//p | .//ext-link[@ext-link-type='uri']">
       <xsl:value-of select="normalize-space(.)"/>

--- a/src/pubget/_text.py
+++ b/src/pubget/_text.py
@@ -14,7 +14,7 @@ _LOG = logging.getLogger(__name__)
 class TextExtractor(Extractor):
     """Extracting text from XML articles."""
 
-    fields = ("pmcid", "title", "keywords", "abstract", "body")
+    fields = ("pmcid", "title", "keywords", "abstract", "body", "datasets")
     name = "text"
 
     def extract(

--- a/src/pubget/_text.py
+++ b/src/pubget/_text.py
@@ -14,7 +14,7 @@ _LOG = logging.getLogger(__name__)
 class TextExtractor(Extractor):
     """Extracting text from XML articles."""
 
-    fields = ("pmcid", "title", "keywords", "abstract", "body", "datasets")
+    fields = ("pmcid", "title", "keywords", "abstract", "body")
     name = "text"
 
     def extract(


### PR DESCRIPTION
See #51

I updated the [text_extraction.xml](https://github.com/neuroquery/pubget/blob/main/src/pubget/_data/stylesheets/text_extraction.xsl) stylesheet to keep external links without affecting readability and also searched for more articles to know where public datasets text tends to be and updated the stylesheet to handle that accordindly. i have attached a copy of my extracted text data from some articles i gathered including the example in the issue too.
[text.csv](https://github.com/user-attachments/files/17003081/text.csv)

